### PR TITLE
Use standardized dependency-groups instead legacy dev-depndencies in the pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,14 @@ classifiers = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.3.2",
     "pdbpp>=0.10.3",
     "inline-snapshot>=0.12.1",
     "uvicorn>=0.30.6",
     "fastapi[standard]>=0.112.2",
+]
+lint = [
     "mypy>=1.11.2",
 ]


### PR DESCRIPTION
After PEP 735 was accepted uv started to use dependency-groups.
I advise you to remove legacy dev-depndencies and use suggested by PEP-735 dependency-groups.
The main reason is that it is needed for a packaging your python module for linux distributions.