### PR TITLE
Changed stdin reads in _get_terminal_color to non-blocking

### DIFF
--- a/src/rich_toolkit/utils/colors.py
+++ b/src/rich_toolkit/utils/colors.py
@@ -160,14 +160,20 @@ def _get_terminal_color(
             # Read response
             response = ""
             while True:
-                char = sys.stdin.read(1)
+                try:
+                    char = sys.stdin.read(1)
+                except io.BlockingIOError:
+                    char = ""
+                except TypeError:
+                    char = ""
+                if char is None or char == "":  # No more response data available
+                    break
+
                 response += char
 
                 if char == "\\":  # End of OSC response
                     break
                 if len(response) > 50:  # Safety limit
-                    break
-                if char is None or char == "":  # No more response data available
                     break
 
             # Parse the response (format: \033]10;rgb:RRRR/GGGG/BBBB\033\\)


### PR DESCRIPTION
In this pull request, I try to address the issue I mentioned in #24

## The Issue

On certain (rare) occasions, the OSC response containing the terminal color that is parsed in _get_terminal_color might have an unexpected format. In these cases, the current implementation might freeze.

I was not able to reliably reproduce the issue, however it's possible to simulate the issue by replacing the expected "end of OSC response" character in line [163](https://github.com/patrick91/rich-toolkit/blob/main/src/rich_toolkit/utils/colors.py#L163) by an incorrect character, e.g. "!". Then, the function should always freeze, if the OSC response is less than 50 characters long.

## The solution

My suggested solution is to set sys.stdin to perform non-blocking reads. In my tests, that resolved the issue.
I have to admit that I am not an expert when it comes to these Python functions. I'm not sure if the try-except block is required (it wasn't in any of my tests, but a quick Google search revealed that these exception might be or have been raised here).