### PR TITLE
Show cancelled state when progress is interrupted

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+---
+release type: patch
+---
+
+Show cancelled state when progress is interrupted with Ctrl+C.
+
+Previously, pressing Ctrl+C during a progress operation would exit without
+any visual indication that the operation was cancelled. Now, the progress
+displays "Cancelled." (matching how inputs and menus already handle cancellation).
+
+The tagged style also shows the tag blocks in red (using error animation colors)
+when a progress is cancelled.

--- a/examples/progress_cancelled.py
+++ b/examples/progress_cancelled.py
@@ -1,0 +1,35 @@
+"""Example showing the cancelled state of progress.
+
+Run this and press Ctrl+C while the progress is running to see the cancelled state.
+The tagged style will show the tag blocks in red, and "Cancelled." will be displayed.
+"""
+
+import time
+
+from rich_toolkit import RichToolkit, RichToolkitTheme
+from rich_toolkit.styles.tagged import TaggedStyle
+
+style = TaggedStyle(tag_width=8)
+
+theme = RichToolkitTheme(
+    style=style,
+    theme={
+        "tag.title": "black on #A7E3A2",
+        "tag": "white on #893AE3",
+        "placeholder": "grey85",
+        "text": "white",
+        "selected": "green",
+        "result": "grey85",
+        "progress": "on #893AE3",
+        "error": "red",
+    },
+)
+
+with RichToolkit(theme=theme) as app:
+    app.print_title("Cancelled progress example", tag="demo")
+    app.print_line()
+
+    with app.progress("Installing dependencies") as progress:
+        for i in range(10):
+            time.sleep(0.5)
+            progress.log(f"Installing package {i + 1}/10...")

--- a/src/rich_toolkit/progress.py
+++ b/src/rich_toolkit/progress.py
@@ -53,6 +53,12 @@ class Progress(Live, Element):
 
         return self
 
+    def __exit__(self, exc_type: type | None, *args: object) -> None:
+        if exc_type is KeyboardInterrupt:
+            self._cancelled = True
+
+        super().__exit__(exc_type, *args)
+
     def get_renderable(self) -> RenderableType:
         return self.style.render_element(self, done=not self._started)
 

--- a/src/rich_toolkit/styles/base.py
+++ b/src/rich_toolkit/styles/base.py
@@ -448,6 +448,13 @@ class BaseStyle:
         done: bool = False,
         parent: Optional[Element] = None,
     ) -> RenderableType:
+        if done and element._cancelled:
+            return Text.assemble(
+                element.title,
+                " ",
+                ("Cancelled.", self.console.get_style("cancelled")),
+            )
+
         content: str | Group | Text = element.current_message
 
         if element.logs and element._inline_logs:

--- a/src/rich_toolkit/styles/border.py
+++ b/src/rich_toolkit/styles/border.py
@@ -148,6 +148,14 @@ class BorderedStyle(BaseStyle):
         done: bool = False,
         parent: Optional[Element] = None,
     ) -> RenderableType:
+        if done and element._cancelled:
+            content = Text.assemble(
+                ("Cancelled.", self.console.get_style("cancelled")),
+            )
+            return self._box(
+                content, element.title, is_active, border_color=Color.parse("white")
+            )
+
         content: str | Group | Text = element.current_message
         title: Union[str, Text, None] = None
 

--- a/tests/test_progress_cancelled.py
+++ b/tests/test_progress_cancelled.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from rich.text import Text
+
+from rich_toolkit.progress import Progress
+from rich_toolkit.styles.base import BaseStyle
+from rich_toolkit.styles.border import BorderedStyle
+
+
+def test_progress_cancelled_flag_set_on_keyboard_interrupt():
+    """KeyboardInterrupt during progress should set _cancelled to True."""
+    style = BaseStyle()
+    progress = Progress("Installing...", style=style)
+
+    progress.start()
+    progress.__exit__(KeyboardInterrupt, None, None)
+
+    assert progress._cancelled is True
+
+
+def test_progress_cancelled_flag_not_set_on_normal_exit():
+    """Normal exit should not set _cancelled."""
+    style = BaseStyle()
+    progress = Progress("Installing...", style=style)
+
+    progress.start()
+    progress.__exit__(None, None, None)
+
+    assert progress._cancelled is False
+
+
+def test_render_cancelled_progress_base_style():
+    """Cancelled progress should render title with 'Cancelled.' in base style."""
+    style = BaseStyle()
+    progress = Progress("Installing...", style=style)
+    progress._cancelled = True
+
+    result = style.render_progress(progress, done=True)
+
+    assert isinstance(result, Text)
+    assert "Installing..." in result.plain
+    assert "Cancelled." in result.plain
+
+
+def test_render_cancelled_progress_border_style():
+    """Cancelled progress should render 'Cancelled.' in border style."""
+    style = BorderedStyle()
+    progress = Progress("Installing...", style=style)
+    progress._cancelled = True
+
+    result = style.render_progress(progress, done=True)
+
+    # Border style wraps in a box, so check the rendered string
+    style.console.begin_capture()
+    style.console.print(result)
+    output = style.console.end_capture()
+
+    assert "Cancelled." in output
+
+
+def test_render_non_cancelled_progress_does_not_show_cancelled():
+    """Normal (non-cancelled) progress should not show 'Cancelled.'."""
+    style = BaseStyle()
+    progress = Progress("Installing...", style=style)
+
+    result = style.render_progress(progress, done=True)
+
+    # result is the current_message string, not a Text with "Cancelled."
+    if isinstance(result, Text):
+        assert "Cancelled." not in result.plain
+    else:
+        assert "Cancelled." not in str(result)


### PR DESCRIPTION
## Summary
- Override `__exit__` on `Progress` to set `_cancelled = True` when a `KeyboardInterrupt` occurs, matching how `Input` and `Menu` already handle cancellation
- Update `render_progress` in both base and border styles to display "Cancelled." when the progress was interrupted
- Add tests for the cancelled flag behavior and rendering in both styles

## Test plan
- [x] Existing tests pass (81 total)
- [x] New tests cover: flag set on interrupt, flag not set on normal exit, cancelled rendering in base style, cancelled rendering in border style, non-cancelled progress unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request makes Progress cancellation explicit and surfaced in rendering: when a Progress is interrupted by a KeyboardInterrupt it now records a cancelled state and styles renderers display a "Cancelled." indicator. The change aligns Progress behaviour with Input and Menu cancellation handling and propagates a cancelled/error animation status into the tagged style.

## Changes made

**Progress class** (src/rich_toolkit/progress.py)
- Added an override of __exit__ that sets self._cancelled = True when exc_type is KeyboardInterrupt, then delegates to super().__exit__.
- Progress.get_renderable now uses the style.render_element path unchanged; _cancelled is the source of cancelled state.

**BaseStyle rendering** (src/rich_toolkit/styles/base.py)
- render_progress now returns early when done is True and element._cancelled is True, producing a Text that includes the element title and a "Cancelled." label styled with the "cancelled" style.

**BorderedStyle rendering** (src/rich_toolkit/styles/border.py)
- render_progress now returns a boxed panel containing a styled "Cancelled." message (using the "cancelled" style) when done and element._cancelled, bypassing normal progress content.
- Animation for the box border still applies when not done.

**TaggedStyle rendering & APIs** (src/rich_toolkit/styles/tagged.py)
- Introduced an animation_status parameter (Literal["started","stopped","error"] | None) to _get_tag_segments, _get_tag and _tag_element.
- When rendering tagged elements, TaggedStyle sets animation_status = "error" for cancelled Progress elements so tag blocks use the error animation colours.
- Default animation_status is inferred (started when not done, stopped when done) when not provided; this centralises animation-state propagation for tags.

**Examples**
- Added examples/progress_cancelled.py demonstrating the cancelled state (tagged style shows red blocks and "Cancelled." when interrupted).

## Tests

Added tests/tests_progress_cancelled.py (tests/test_progress_cancelled.py) covering:
- _cancelled flag set on KeyboardInterrupt and not set on normal exit.
- BaseStyle render shows title + "Cancelled." when cancelled.
- BorderedStyle render boxes and prints "Cancelled." when cancelled.
- TaggedStyle renders "Cancelled." and uses error animation colours for tag blocks when cancelled.
- Non-cancelled progress does not show "Cancelled."

All existing tests (81) pass alongside the new tests.

## Notes for reviewers

- Behavioural change is limited to setting and rendering the cancelled state; public APIs otherwise remain compatible.
- TaggedStyle method signatures were extended to accept animation_status — callers internal to styles are updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->