### PR TITLE
Add support for `end` to print

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+---
+release type: patch
+---
+
+This release adds support for passing `end` to `RichToolkit.print()`,
+`RichToolkit.print_title()`, and `Progress.log()`.
+
+This makes it possible to print or log partial lines without automatically
+ending them with a newline:
+
+```python
+app.print("Hello, ", end="")
+app.print("World!")
+
+with app.progress("Downloading") as progress:
+    progress.log("Downloaded ", end="")
+    progress.log("50%")
+```

--- a/examples/end.py
+++ b/examples/end.py
@@ -1,0 +1,47 @@
+import time
+
+from rich_toolkit import RichToolkit
+from rich_toolkit.styles.border import BorderedStyle
+from rich_toolkit.styles.fancy import FancyStyle
+from rich_toolkit.styles.tagged import TaggedStyle
+
+theme = {
+    "tag.title": "black on #A7E3A2",
+    "tag": "white on #893AE3",
+    "placeholder": "grey85",
+    "text": "white",
+    "selected": "green",
+    "result": "grey85",
+    "progress": "on #893AE3",
+    "error": "red",
+}
+
+for style in [
+    TaggedStyle(tag_width=10, theme=theme),
+    FancyStyle(theme=theme),
+    BorderedStyle(theme=theme),
+]:
+    with RichToolkit(style=style) as app:
+        app.print_title("Print without newlines", tag="demo")
+        app.print_line()
+
+        app.print("Creating ", end="")
+        time.sleep(0.4)
+        app.print("project ", end="")
+        time.sleep(0.4)
+        app.print("done", tag="result")
+
+        app.print_line()
+
+        with app.progress(
+            "Progress logs without newlines",
+            inline_logs=True,
+            lines_to_show=4,
+        ) as progress:
+            for step in ["Resolving", "Downloading", "Installing", "Finalizing"]:
+                progress.log(f"{step} ", end="")
+                time.sleep(0.3)
+                progress.log("done")
+                time.sleep(0.2)
+
+    print("----------------------------------------")

--- a/src/rich_toolkit/progress.py
+++ b/src/rich_toolkit/progress.py
@@ -40,6 +40,7 @@ class Progress(Live, Element):
         self.lines_to_show = lines_to_show
 
         self.logs: List[ProgressLine] = []
+        self._log_line_open = False
 
         self._cancelled = False
 
@@ -61,13 +62,32 @@ class Progress(Live, Element):
     def get_renderable(self) -> RenderableType:
         return self.style.render_element(self, done=not self._started)
 
-    def log(self, text: str | Text) -> None:
+    def _append_text(self, target: str | Text, text: str | Text) -> str | Text:
+        if isinstance(target, str) and isinstance(text, str):
+            return target + text
+
+        return Text.assemble(target, text)
+
+    def log(self, text: str | Text, end: str = "\n") -> None:
+        should_append = self._log_line_open
+        self._log_line_open = not end.endswith("\n")
+
+        if end != "\n":
+            text = self._append_text(text, end)
+
         if self._inline_logs:
-            self.logs.append(ProgressLine(text, self))
+            if should_append and self.logs:
+                self.logs[-1].text = self._append_text(self.logs[-1].text, text)
+            else:
+                self.logs.append(ProgressLine(text, self))
         else:
-            self.current_message = text
+            if should_append:
+                self.current_message = self._append_text(self.current_message, text)
+            else:
+                self.current_message = text
 
     def set_error(self, text: str) -> None:
         self.current_message = text
         self.is_error = True
         self.transient = self._transient_on_error
+        self._log_line_open = False

--- a/src/rich_toolkit/toolkit.py
+++ b/src/rich_toolkit/toolkit.py
@@ -56,15 +56,20 @@ class RichToolkit:
 
         return None
 
-    def print_title(self, title: str, **metadata: Any) -> None:
-        self.console.print(self.style.render_element(title, title=True, **metadata))
+    def print_title(self, title: str, end: str = "\n", **metadata: Any) -> None:
+        self.console.print(
+            self.style.render_element(title, title=True, **metadata), end=end
+        )
 
-    def print(self, *renderables: RenderableType, **metadata: Any) -> None:
+    def print(
+        self, *renderables: RenderableType, end: str = "\n", **metadata: Any
+    ) -> None:
         self.console.print(
             *[
                 self.style.render_element(renderable, **metadata)
                 for renderable in renderables
-            ]
+            ],
+            end=end,
         )
 
     def print_as_string(self, *renderables: RenderableType, **metadata: Any) -> str:

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -4,7 +4,8 @@ from inline_snapshot import snapshot
 from rich.tree import Tree
 
 from rich_toolkit import RichToolkit
-from rich_toolkit.styles import FancyStyle
+from rich_toolkit.progress import Progress
+from rich_toolkit.styles import FancyStyle, MinimalStyle
 from ._utils import trim_whitespace_on_lines
 
 style = FancyStyle(theme={})
@@ -28,6 +29,17 @@ def test_can_print_strings(capsys: CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
 
     assert trim_whitespace_on_lines(captured.out) == snapshot("◆ Hello, World!")
+
+
+def test_can_print_without_newline(capsys: CaptureFixture[str]) -> None:
+    app = RichToolkit(style=MinimalStyle(theme={}))
+
+    app.print("Hello, ", end="")
+    app.print("World!")
+
+    captured = capsys.readouterr()
+
+    assert captured.out == snapshot("Hello, World!\n")
 
 
 def test_can_print_renderables(capsys: CaptureFixture[str]) -> None:
@@ -83,3 +95,26 @@ def test_ignores_keyboard_interrupt(capsys: CaptureFixture[str]) -> None:
     with pytest.raises(KeyboardInterrupt):
         with app:
             raise KeyboardInterrupt()
+
+
+def test_progress_log_can_append_without_newline() -> None:
+    progress = Progress("Loading", style=MinimalStyle(theme={}))
+
+    progress.log("Downloading ", end="")
+    progress.log("50%")
+    assert progress.current_message == snapshot("Downloading 50%")
+
+    progress.log("Done")
+    assert progress.current_message == snapshot("Done")
+
+
+def test_inline_progress_log_can_append_without_newline() -> None:
+    progress = Progress("Loading", style=MinimalStyle(theme={}), inline_logs=True)
+
+    progress.log("Downloading ", end="")
+    progress.log("50%")
+    progress.log("Done")
+
+    assert [line.text for line in progress.logs] == snapshot(
+        ["Downloading 50%", "Done"]
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.8.1'",
 ]
 
+[options]
+exclude-newer = "2026-05-09T12:23:13.79987Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#56** (`add-support-for-end-to-print`) <-- this PR
<!-- shortcake:end -->