### PR TITLE
Skip terminal color query when not in foreground process group

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+---
+release type: patch
+---
+
+This release fixes the terminal color query hanging when the program runs from
+a background process group.
+
+`_get_terminal_color` used `tty.setcbreak`, which calls `tcsetattr` and
+generates `SIGTTOU` when invoked from a background process group (for example
+when the program is launched with `prog &` or run under a job-control shell
+that isn't giving it the terminal). The default disposition of `SIGTTOU` stops
+the process, so the program would hang.
+
+It now checks that it owns the terminal's foreground process group before
+querying, and falls back to the default color otherwise.

--- a/src/rich_toolkit/utils/colors.py
+++ b/src/rich_toolkit/utils/colors.py
@@ -152,6 +152,19 @@ def _get_terminal_color(
         os.close(tty_fd)
         return default_color
 
+    # Only proceed if we're the foreground process group for this terminal.
+    # Calling tcsetattr (via setcbreak) from a background process group
+    # generates SIGTTOU, which by default stops the process. This happens
+    # e.g. when the program is launched in the background (`prog &`) or run
+    # under a job-control shell that isn't giving us the terminal.
+    try:
+        if os.tcgetpgrp(tty_fd) != os.getpgrp():
+            os.close(tty_fd)
+            return default_color
+    except OSError:
+        os.close(tty_fd)
+        return default_color
+
     old_settings = termios.tcgetattr(tty_fd)
 
     try:


### PR DESCRIPTION
## Problem

`_get_terminal_color` calls `tty.setcbreak(tty_fd)`, which internally calls `tcsetattr`. When the program runs from a **background process group** (e.g. launched with `prog &`, or under a job-control shell that isn't giving us the terminal), `tcsetattr` generates `SIGTTOU`. The default disposition of `SIGTTOU` **stops the process**, so the program hangs.

## Fix

Before querying the terminal, check that we own the terminal's foreground process group via `os.tcgetpgrp(tty_fd) == os.getpgrp()`. If we don't (or the check raises `OSError`), fall back to the default color instead of touching termios settings.

This is done after acquiring the flock and before `setcbreak`, so no terminal state is modified in the background case. Closing the fd releases the flock, consistent with the existing early-return paths.